### PR TITLE
Move the log file from /usr/share to /var/log

### DIFF
--- a/bin/noderedrevpinodes-server.service
+++ b/bin/noderedrevpinodes-server.service
@@ -5,7 +5,8 @@ Documentation="https://github.com/erminas/noderedrevpinodes-server"
 
 [Service]
 Type=simple
-ExecStart=/bin/sh -c 'exec /usr/bin/python3 -u revpi-server.py 2>> revpi-server.log'
+StandardOutput=append:%L/revpi-server.log
+ExecStart=/usr/bin/python3 -u revpi-server.py
 WorkingDirectory=/usr/share/noderedrevpinodes-server/
 Restart=on-abort
 


### PR DESCRIPTION
Logging to /usr/share is problematic andby the FSH logs should go to
/var/log. Otherwise it is hard to create a read-only rfs. Also /var
might be handaled differently to avoid flash wear out.

Signed-off-by: Philipp Rosenberger <p.rosenberger@kunbus.com>