### PR TITLE
feat: Support IPv6 for backend server

### DIFF
--- a/revpi-server.py
+++ b/revpi-server.py
@@ -199,9 +199,9 @@ class RevPiServer:
         self.revpi.cycleloop(self.cyclefunc, cycletime=self.cycle_time_ms, blocking=False)
 
     def start_websocket_loop(self):
-        ip = '0.0.0.0'
+        ip = ['::', '0.0.0.0']
         if self.block_external_connections:
-            ip = '127.0.0.1'
+            ip = ['::1', '127.0.0.1']
         if distro.codename() == 'stretch':
             ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS)
             localhost_pem = os.path.abspath(self.cert_file)


### PR DESCRIPTION
It has been a while since IPv6 launch day 6.6.2012, so it the NodeRed backend should support IPv6 too. Nearly all systems default to IPv6 and also names like localhost are resolved to their IPv6 address by default. This means if a user enters localhost in NodeJS for the server config it will fail. Fix this by listen to IPv4 and IPv6.